### PR TITLE
AG | Update links on homepage

### DIFF
--- a/content/themes/casper/home.hbs
+++ b/content/themes/casper/home.hbs
@@ -105,7 +105,7 @@
      <tr>
 
        <td style="text-align:center">  
-         <a href="https://github.com/whereat">
+         <a href="https://github.com/whereat/wiki/wiki">
            <img width="100" height="100" style="margin-top: 1em;" src ='/content/images/2015/12/code.svg'> 
            <br/>
            <br/>
@@ -114,11 +114,11 @@
        </td>      
 
        <td style="text-align:center">  
-         <a href="mailto:whereat.admin@riseup.net">
+         <a href="/contact-us">
            <img width="100" height="100" style="margin-top: 1em;" src ='/content/images/2015/12/mail.svg'> 
            <br/>
            <br/>
-           <p><strong>Email us</strong></p>
+           <p><strong>Contact us</strong></p>
          </a>
        </td>      
 


### PR DESCRIPTION
In order to create more welcoming paths to access for newcomers:
- Point "write code" link to `wiki/wiki` instead of `github/whereat`
  - reason: lots more context here! plain list of repos was disorienting!
- Point "contact us" link to (new) `whereat.io/contact-us` page
  - reason: we now have lots more ways to talk to people than email!
    this lets people contact us in the medium they feel most comfortable with
